### PR TITLE
Upgrade to newer forked mapnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Konstantin Käfer <kkaefer@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mapbox/node-blend.git"
+    "url": "https://github.com/kartotherian/node-blend.git"
   },
   "publishConfig": {
     "access": "public"
@@ -28,7 +28,7 @@
     "eslint-config-unstyled": "^1.1.0"
   },
   "dependencies": {
-    "@kartotherian/mapnik": "~3.7.3"
+    "@kartotherian/mapnik": "~3.7.3-wikimedia.0"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kartotherian/blend",
   "description": "High speed image blending and quantization",
-  "version": "2.0.1",
+  "version": "2.0.1-wikimedia.0",
   "homepage": "http://github.com/mapbox/node-blend",
   "author": "Konstantin Käfer <kkaefer@gmail.com>",
   "repository": {


### PR DESCRIPTION
This version always builds from source, hopefully preventing some
npm-install errors.

Also bumps the git repo to point to our fork.

Bug: T295046